### PR TITLE
Add json API for listing today's awesome people

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "figaro"
 # Authentication
 gem "omniauth-github"
 
+gem "active_model_serializers"
+
 group :development, :test do
   gem "capybara"
   gem "database_cleaner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,10 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.3)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (= 0.1.1.beta2)
     activejob (4.2.5)
       activesupport (= 4.2.5)
       globalid (>= 0.3.0)
@@ -77,6 +81,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     jwt (1.5.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -194,6 +200,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   capybara
   coffee-rails
   database_cleaner
@@ -214,4 +221,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/app/controllers/api/v1/claims_controller.rb
+++ b/app/controllers/api/v1/claims_controller.rb
@@ -1,0 +1,9 @@
+module API
+  module V1
+    class ClaimsController < ActionController::Base
+      def today
+        render json: User.claiming_today
+      end
+    end
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -3,7 +3,5 @@ class Claim < ActiveRecord::Base
 
   validates :user, :date, presence: true, strict: true
 
-  def self.today
-    where(date: Date.current).order(:created_at)
-  end
+  scope :today, -> { where(date: Date.current).order(created_at: :asc) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
 
   def display_name
     match = name.to_s.match(/\A(?<first_name>[^ ]+) [^ ]+\z/)
-    match && match[:first_name] || name || "@#{github_login}"
+    match && match[:first_name] || name.presence || "@#{github_login}"
   end
 
   def github_url

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :display_name, :github_login
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,12 @@ Rails.application.routes.draw do
   get "claim" => "claims#create"
 
   root to: "claims#new"
+
+  namespace :api do
+    namespace :v1 do
+      resources :claims, only: [] do
+        get :today, on: :collection
+      end
+    end
+  end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -1,0 +1,65 @@
+describe "Today's Claims" do
+  let(:json) { JSON.parse(response.body) }
+
+  it "responds successfully" do
+    get "/api/v1/claims/today"
+    expect(response.code).to eq "200"
+  end
+
+  it "responds with json" do
+    get "/api/v1/claims/today"
+    expect(response["Content-Type"]).to eq "application/json; charset=utf-8"
+  end
+
+  it "lists users bringing donuts today" do
+    user1 = create(:user, name: "Laura Mosher", github_login: "laura")
+    user2 = create(:user, name: "Chris Gaffney", github_login: "chris")
+    create(:claim, user: user1, date: Date.current)
+    create(:claim, user: user2, date: Date.current)
+
+    get "/api/v1/claims/today"
+    expect(json).to eq [
+      {
+        "id" => user1.id,
+        "name" => "Laura Mosher",
+        "display_name" => "Laura",
+        "github_login" => "laura",
+      },
+      {
+        "id" => user2.id,
+        "name" => "Chris Gaffney",
+        "display_name" => "Chris",
+        "github_login" => "chris",
+      },
+    ]
+  end
+
+  it "doesn't list users who didn't bring donuts" do
+    create(:user)
+
+    get "/api/v1/claims/today"
+    expect(json).to eq []
+  end
+
+  it "doesn't list users who brought donuts yesterday" do
+    create(:claim, date: Date.yesterday)
+
+    get "/api/v1/claims/today"
+    expect(json).to eq []
+  end
+
+  it "only lists the user once if they brought donuts more than once" do
+    user = create(:user, name: "Laura", github_login: "laura")
+    create_list(:claim, 3, user: user, date: Date.current)
+
+    get "/api/v1/claims/today"
+    expect(json).to eq [
+      {
+        "id" => user.id,
+        "name" => "Laura",
+        "display_name" => "Laura",
+        "github_login" => "laura",
+      },
+    ]
+  end
+end


### PR DESCRIPTION
Adds the endpoint `/api/v1/claims/today` to fetch a list of users
who have claimed bringing donuts for the current date. URL does not
require authentication to access.

Example:

```json
[
  {
    "id": "57ba9574-550a-4aba-9fcd-d2ded5a5cef0",
    "name": "",
    "display_name": "@mystery",
    "github_login": "mystery",
  },
  {
    "id": "42dae592-8e3f-4b88-8e42-a799ffa6ee16",
    "name": "Jane Doe",
    "display_name": "Jane",
    "github_login": "jane",
  },
  {
    "id": "4684c51a-5729-4a82-bcc8-afffcbcf87e2",
    "name": "John Doe",
    "display_name": "John",
    "github_login": "john",
  }
]
```

I also upgraded to ruby 2.3.3 and Rails 4.2.7.1, added rubocop config, and udpated dependencies.