### PR TITLE
Add rubocop for auto-formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,102 @@
+# Load the rubocop-rspec gem
+require: rubocop-rspec
+
+Rails:
+  Enabled: true
+AllCops:
+  Exclude:
+    - 'db/schema.rb'
+
+#################
+# [i] Overrides #
+#################
+
+Style/CollectionMethods:
+  Enabled: true
+  # Mapping from undesired method to desired_method
+  # e.g. to use `detect` over `find`:
+  #
+  # CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
+  PreferredMethods:
+    reduce: 'inject'
+    find: 'detect'
+    each_with_index: 'each.with_index'
+
+# Align ends correctly.
+EndAlignment:
+  AlignWith: variable
+
+IfUnlessModifier:
+  MaxLineLength: 75
+
+LineLength:
+  Max: 200
+
+SignalException:
+  EnforcedStyle: only_raise
+
+SpaceInsideBlockBraces:
+  SpaceBeforeBlockParameters: true
+
+SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+
+BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+
+StringLiterals:
+  EnforcedStyle: double_quotes
+
+#################
+# Disabled cops #
+#################
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/FormatString:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+# HABTM still has a place.
+# http://collectiveidea.com/blog/archives/2014/08/11/has_and_belongs_to_many-isnt-dead/
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+# RSpec examples are ok if they're long.
+# Explicitness is better than cleverness in tests.
+RSpec/ExampleLength:
+  Enabled: false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,11 @@
 module ApplicationHelper
   def linked_names(users)
-    users.map { |user|
+    users.map do |user|
       link_to user.display_name, user.github_url, target: "_blank"
-    }.to_sentence.html_safe
+    end.to_sentence.html_safe
   end
+
   def users_list(users)
-    users.map { |user|
-      user.display_name
-    }.to_sentence.html_safe
+    users.map(&:display_name).to_sentence.html_safe
   end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,4 +1,6 @@
-Figaro.require_keys(%w[
-  GITHUB_KEY
-  GITHUB_SECRET
-])
+Figaro.require_keys(
+  %w(
+    GITHUB_KEY
+    GITHUB_SECRET
+  )
+)


### PR DESCRIPTION
Adds rubocop configuration from our standard config with modifications to follow the currently used spacing style around curly brackets for blocks and hashes.